### PR TITLE
remove aem author env check from buildConfigURL()

### DIFF
--- a/scripts/configs.js
+++ b/scripts/configs.js
@@ -39,17 +39,9 @@ function buildConfigURL(environment) {
   if (env !== 'prod') {
     fileName = `configs-${env}.json`;
   }
- 
-      
-      /* eslint-disable-next-line no-use-before-define */
-      if (getAemAuthorEnv()) {
-        // eslint-disable-next-line no-use-before-define
-        const aemContentPath = getAemContentPath();
-        return new URL(`${window.location.origin}${aemContentPath}/${fileName}`);
-      }
-      const configURL = new URL(`${window.location.origin}/${fileName}`);
-      return configURL;  
-  } 
+  const configURL = new URL(`${window.location.origin}/${fileName}`);
+  return configURL;  
+} 
 
 const getConfigForEnvironment = async (environment) => {
   const env = environment || calcEnvironment();


### PR DESCRIPTION
The `getAemAuthorEnv()` check is not needed since the service worker sw.js that is part of xwalk will take care of mapping the file name correctly automatically.

This currently causes citisignal commerce installations to fail on the new AEM releease 2025.1 as spreadsheets now get additionally a `.hlx.` extension added (see [SITES-23533](https://jira.corp.adobe.com/browse/SITES-23533) ) so it should be e.g. `/configs.hlx.json`, which gets added by [sw.js](https://git.corp.adobe.com/CQ/sites-franklin/blob/main/content/sites-franklin-content/jcr_root/libs/core/franklin/components/page/v1/page/clientlibs/serviceworker5/serviceWorker5.js#L1-L12)