### PR TITLE
Carousel: UE stops working if carousel has multiple slides

### DIFF
--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -1,3 +1,7 @@
+.carousel {
+  --transition-time: 5000ms;
+}
+
 .carousel .carousel-slides-container {
   position: relative;
 }
@@ -121,12 +125,15 @@
   border-radius: 1rem;
   height: 100%;
   background-color: rgba(0 0 0 / 80%);
+  width:0%;
+  transition: width var(--transition-time) linear;
 }
 
 .carousel .carousel-slide-indicator button:disabled,
 .carousel .carousel-slide-indicator button:hover,
 .carousel .carousel-slide-indicator button:focus-visible {
   background-color: rgba(0 0 0 / 80%);
+  width: 100%;
 }
 
 .carousel .carousel-slide-indicator span,

--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -126,6 +126,7 @@
   height: 100%;
   background-color: rgba(0 0 0 / 80%);
   width:0%;
+  transition: none;
 }
 
 .carousel .carousel-slide-indicator button.animate {

--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -126,14 +126,17 @@
   height: 100%;
   background-color: rgba(0 0 0 / 80%);
   width:0%;
+}
+
+.carousel .carousel-slide-indicator button.animate {
   transition: width var(--transition-time) linear;
+  width: 100%;
 }
 
 .carousel .carousel-slide-indicator button:disabled,
 .carousel .carousel-slide-indicator button:hover,
 .carousel .carousel-slide-indicator button:focus-visible {
   background-color: rgba(0 0 0 / 80%);
-  width: 100%;
 }
 
 .carousel .carousel-slide-indicator span,

--- a/blocks/carousel/carousel.js
+++ b/blocks/carousel/carousel.js
@@ -111,14 +111,14 @@ function bindEvents(block) {
 
   // on mouseleave, restart autoscroll
   block.addEventListener('mouseleave', (e) => {
+    // restart autosrolling
+    block.dataset.timeoutId = setTimeout(timeout, block.dataset.timeoutMs,block);
     // restart interval for active indicator 
     block.querySelectorAll('.carousel-slide-indicator > button').forEach((indicator,idx) => {
       if (block.dataset.activeSlide == idx) {
         indicator.classList.add('animate');
       }
     });
-    // restart autosrolling
-    block.dataset.timeoutId = setTimeout(timeout, block.dataset.timeoutMs,block);
   });
 
   // start autoscrolling

--- a/blocks/carousel/carousel.js
+++ b/blocks/carousel/carousel.js
@@ -11,7 +11,7 @@ export function stopAutoScroll(block) {
   const timeoutId = block.dataset.timeoutId;
   if (timeoutId) {
     clearTimeout(timeoutId);
-    block.dataset.timeoutId = null;
+    delete block.dataset.timeoutId;
   }
 }
 
@@ -70,7 +70,7 @@ export function showSlide(block, slideIndex = 0) {
   const activeSlide = slides[realSlideIndex];
 
   if (!activeSlide) return;
-  
+
   activeSlide.querySelectorAll('a').forEach((link) => link.removeAttribute('tabindex'));
   block.querySelector('.carousel-slides').scrollTo({
     top: 0,

--- a/blocks/carousel/carousel.js
+++ b/blocks/carousel/carousel.js
@@ -3,11 +3,7 @@ import { moveInstrumentation } from '../../scripts/scripts.js';
 
 export function timeout(block) {
   // if block is no longer in the document e.g. after a refresh/reload/edit, kick it.
-  if(!document.documentElement.contains(block)) {
-    // make sure to clear timeout
-    clearTimeout(block.dataset.timeoutId);
-    return;
-  };
+  if(!document.documentElement.contains(block)) return;
   // get number of slides
   const slides = block.querySelectorAll('.carousel-slide').length;
   // get next active 
@@ -110,13 +106,13 @@ function bindEvents(block) {
     // remove indicator animation
     block.querySelector('.carousel-slide-indicator > button.animate')?.classList.remove('animate');
     // stop autoscrolling
-    clearTimeout(block.dataset.timeoutIId);
+    clearTimeout(block.dataset.timeoutId);
   });
 
   // on mouseleave, restart autoscroll
   block.addEventListener('mouseleave', (e) => {
     // restart interval for active indicator 
-    block.querySelector('.carousel-slide-indicator > button').forEach((indicator,idx) => {
+    block.querySelectorAll('.carousel-slide-indicator > button').forEach((indicator,idx) => {
       if (block.dataset.activeSlide == idx) {
         indicator.classList.add('animate');
       }

--- a/blocks/carousel/carousel.js
+++ b/blocks/carousel/carousel.js
@@ -115,8 +115,6 @@ function bindEvents(block) {
 
   // on mouseenter , cancel autoscroll
   block.addEventListener('mouseenter', (e) => {
-    // remove indicator animation
-    block.querySelector('.carousel-slide-indicator > button.animate')?.classList.remove('animate');
     // stop autoscrolling
     stopAutoScroll(block);
   });

--- a/blocks/carousel/carousel.js
+++ b/blocks/carousel/carousel.js
@@ -123,12 +123,6 @@ function bindEvents(block) {
   block.addEventListener('mouseleave', (e) => {
     // restart autosrolling
     startAutoScroll(block);
-    // restart interval for active indicator 
-    block.querySelectorAll('.carousel-slide-indicator > button').forEach((indicator,idx) => {
-      if (block.dataset.activeSlide == idx) {
-        indicator.classList.add('animate');
-      }
-    });
   });
 
   // start autoscrolling

--- a/blocks/carousel/carousel.js
+++ b/blocks/carousel/carousel.js
@@ -3,7 +3,7 @@ import { moveInstrumentation } from '../../scripts/scripts.js';
 
 
 export function startInterval(block) {
-  if (block.dataset.intervalTime > 0) {
+  if (block.dataset.intervalTime > 0 && !block.dataset.intervalTime) {
     block.dataset.intervalId = setInterval(() => {
       // get number of slides
       const slides = block.querySelectorAll('.carousel-slide').length;
@@ -16,9 +16,12 @@ export function startInterval(block) {
 }
 
 export function stopInterval(block) {
-  if (block.dataset.intervalId) {
-    clearInterval(block.dataset.intervalId);
-    delete block.dataset.intervalId;
+  console.log(block.dataset.intervalId);
+  const intervalId = block.dataset.intervalId;
+  // NOTE: needed to avoid concurrency issues
+  if (intervalId) {
+    clearInterval(intervalId);
+    delete block.dataset.intervalTime;
   }
 }
 

--- a/blocks/carousel/carousel.js
+++ b/blocks/carousel/carousel.js
@@ -12,7 +12,7 @@ export function timeout(block) {
   // show it
   showSlide(block, block.dataset.activeSlide);
   // start next waitng cycle
-  block.dataset.timeoutIId = setTimeout(timeout,block.dataset.timeoutMs,block);
+  block.dataset.timeoutId = setTimeout(timeout,block.dataset.timeoutMs,block);
 }
 
 function updateActiveSlide(slide) {

--- a/blocks/carousel/carousel.js
+++ b/blocks/carousel/carousel.js
@@ -2,20 +2,16 @@ import { fetchPlaceholders } from '../../scripts/aem.js';
 import { moveInstrumentation } from '../../scripts/scripts.js';
 
 export function startAutoScroll(block) {
-  if (!block.dataset.timeoutId) {
-    block.dataset.timeoutId = setTimeout(timeout, block.dataset.timeoutMs, block);
-  }
+  block.dataset.timeoutId = setTimeout(timeout, block.dataset.timeoutMs, block);
 }
 
 export function stopAutoScroll(block) {
-  const timeoutId = block.dataset.timeoutId;
-  if (timeoutId) {
-    clearTimeout(timeoutId);
-    delete block.dataset.timeoutId;
-  }
+  clearTimeout(block.dataset.timeoutId);
 }
 
 function timeout(block) {
+  // remove the id
+  delete block.dataset.timeoutId;
   // if block is no longer in the document e.g. after a refresh/reload/edit, kick it.
   if(!document.documentElement.contains(block)) return;
   // get number of slides

--- a/blocks/carousel/carousel.js
+++ b/blocks/carousel/carousel.js
@@ -1,7 +1,21 @@
 import { fetchPlaceholders } from '../../scripts/aem.js';
 import { moveInstrumentation } from '../../scripts/scripts.js';
 
-export function timeout(block) {
+export function startAutoScroll(block) {
+  if (!block.dataset.timeoutId) {
+    block.dataset.timeoutId = setTimeout(timeout, block.dataset.timeoutMs, block);
+  }
+}
+
+export function stopAutoScroll(block) {
+  const timeoutId = block.dataset.timeoutId;
+  if (timeoutId) {
+    clearTimeout(timeoutId);
+    block.dataset.timeoutId = null;
+  }
+}
+
+function timeout(block) {
   // if block is no longer in the document e.g. after a refresh/reload/edit, kick it.
   if(!document.documentElement.contains(block)) return;
   // get number of slides
@@ -11,8 +25,8 @@ export function timeout(block) {
      block.dataset.activeSlide ? (parseInt(block.dataset.activeSlide, 10) + 1) % slides : 0;
   // show it
   showSlide(block, block.dataset.activeSlide);
-  // start next waitng cycle
-  block.dataset.timeoutId = setTimeout(timeout,block.dataset.timeoutMs,block);
+  // start next waiting cycle
+  startAutoScroll(block);
 }
 
 function updateActiveSlide(slide) {
@@ -106,13 +120,13 @@ function bindEvents(block) {
     // remove indicator animation
     block.querySelector('.carousel-slide-indicator > button.animate')?.classList.remove('animate');
     // stop autoscrolling
-    clearTimeout(block.dataset.timeoutId);
+    stopAutoScroll(block);
   });
 
   // on mouseleave, restart autoscroll
   block.addEventListener('mouseleave', (e) => {
     // restart autosrolling
-    block.dataset.timeoutId = setTimeout(timeout, block.dataset.timeoutMs,block);
+    startAutoScroll(block);
     // restart interval for active indicator 
     block.querySelectorAll('.carousel-slide-indicator > button').forEach((indicator,idx) => {
       if (block.dataset.activeSlide == idx) {
@@ -122,7 +136,7 @@ function bindEvents(block) {
   });
 
   // start autoscrolling
-  block.dataset.timeoutId = setTimeout(timeout, block.dataset.timeoutMs,block);
+  startAutoScroll(block);
 }
 
 function createSlide(row, slideIndex, carouselId) {

--- a/blocks/carousel/carousel.js
+++ b/blocks/carousel/carousel.js
@@ -163,7 +163,7 @@ function createSlide(row, slideIndex, carouselId) {
 let carouselId = 0;
 export default async function decorate(block) {
   // read interval time
-  let intervalTime = block.querySelector(":scope > div:first-child > div");
+  let intervalTime = block.querySelector(":scope > div:first-child");
   block.dataset.intervalTime = parseInt(intervalTime.textContent,10);
   intervalTime.remove();
 

--- a/blocks/carousel/carousel.js
+++ b/blocks/carousel/carousel.js
@@ -69,6 +69,8 @@ export function showSlide(block, slideIndex = 0) {
   if (slideIndex >= slides.length) realSlideIndex = 0;
   const activeSlide = slides[realSlideIndex];
 
+  if (!activeSlide) return;
+  
   activeSlide.querySelectorAll('a').forEach((link) => link.removeAttribute('tabindex'));
   block.querySelector('.carousel-slides').scrollTo({
     top: 0,

--- a/blocks/carousel/carousel.js
+++ b/blocks/carousel/carousel.js
@@ -162,6 +162,11 @@ function createSlide(row, slideIndex, carouselId) {
 
 let carouselId = 0;
 export default async function decorate(block) {
+  // read interval time
+  let intervalTime = block.querySelector(":scope > div:first-child > div");
+  block.dataset.intervalTime = parseInt(intervalTime.textContent,10);
+  intervalTime.remove();
+
   carouselId += 1;
   block.setAttribute('id', `carousel-${carouselId}`);
   const rows = block.querySelectorAll(':scope > div');
@@ -235,7 +240,6 @@ export default async function decorate(block) {
   block.prepend(container);
 
   if (!isSingleSlide) {
-    block.dataset.intervalTime = 2000;
     bindEvents(block);
   }
 }

--- a/blocks/carousel/carousel.js
+++ b/blocks/carousel/carousel.js
@@ -212,7 +212,6 @@ export default async function decorate(block) {
     if (classes && classes.length > 0) {
       slide.classList.add(...classes);
     }
-    console.log(row.querySelector(':scope > div'));
     moveInstrumentation(row, slide);
     slidesWrapper.append(slide);
 

--- a/blocks/carousel/carousel.js
+++ b/blocks/carousel/carousel.js
@@ -235,7 +235,7 @@ export default async function decorate(block) {
   block.prepend(container);
 
   if (!isSingleSlide) {
-    block.dataset.intervalTime =1000;
+    block.dataset.intervalTime = 2000;
     bindEvents(block);
   }
 }

--- a/blocks/carousel/carousel.js
+++ b/blocks/carousel/carousel.js
@@ -3,7 +3,7 @@ import { moveInstrumentation } from '../../scripts/scripts.js';
 
 
 export function startInterval(block) {
-  if (block.dataset.intervalTime > 0 && !block.dataset.intervalTime) {
+  if (block.dataset.intervalTime > 0) {
     block.dataset.intervalId = setInterval(() => {
       // get number of slides
       const slides = block.querySelectorAll('.carousel-slide').length;
@@ -21,7 +21,6 @@ export function stopInterval(block) {
   // NOTE: needed to avoid concurrency issues
   if (intervalId) {
     clearInterval(intervalId);
-    delete block.dataset.intervalTime;
   }
 }
 

--- a/component-definition.json
+++ b/component-definition.json
@@ -281,7 +281,8 @@
                 "template": {
                   "name": "Carousel",
                   "model": "carousel",
-                  "filter": "carousel"
+                  "filter": "carousel",
+                  "intervalTime": 5000
                 }
               }
             }

--- a/component-models.json
+++ b/component-models.json
@@ -774,6 +774,19 @@
     ]
   },
   {
+    "id": "carousel",
+    "fields": [
+      {
+        "component": "number",
+        "name": "intervalTime",
+        "value": 5000,
+        "label": "Interval Time",
+        "description": "Time in milliseconds",
+        "valueType": "number"
+      }
+    ]
+  },
+  {
     "id": "carousel-item",
     "fields": [
       {

--- a/scripts/editor-support.js
+++ b/scripts/editor-support.js
@@ -196,21 +196,6 @@ function attachEventListners(main) {
 
 attachEventListners(document.querySelector('main'));
 
-// wait for all caorousels to be loaded before stopping the interval
-/*document.querySelectorAll('.carousel').forEach((carousel) => {
-
-  const observer = new MutationObserver((mutationList, observer) => {
-    for (const mutation of mutationList) {
-      if (mutation.type === "attributes" && mutation.attributeName === "data-block-status" &&
-         mutation.target.getAttribute("data-block-status") === "loaded"){
-          stopInterval(carousel);
-      }
-    }
-  });
-  observer.observe(carousel, { attributes: true, childList: false, subtree: false });
-});*/
-
-
 // when entering edit mode stop scrolling
 document.addEventListener('aue:ui-edit', () => {
   document.querySelectorAll('.block.carousel').forEach( (carousel) => {

--- a/scripts/editor-support.js
+++ b/scripts/editor-support.js
@@ -1,4 +1,4 @@
-import { showSlide, startInterval, stopInterval } from '../blocks/carousel/carousel.js';
+import { showSlide, timeout } from '../blocks/carousel/carousel.js';
 import {
   decorateBlock,
   decorateBlocks,
@@ -43,7 +43,6 @@ function setState(block, state) {
   }
   if (block.matches('.carousel')) {
     block.style.display = null;
-    stopInterval(block);
     createMutation(block);
     showSlide(block, state);
   }
@@ -56,7 +55,7 @@ function setUEFilter(element, filter) {
 
 function updateUEInstrumentation() {
   const main = document.querySelector('main');
-  const template = document.head.querySelector("[name=template]").getAttribute("content");
+  const template = document.head.querySelector("[name=template]")?.getAttribute("content");
   if (template === "marketing") {
     // use marketing specific section
     setUEFilter(main, 'main-marketing');
@@ -197,17 +196,19 @@ function attachEventListners(main) {
 
 attachEventListners(document.querySelector('main'));
 
-// when entering edit mode stop scrolling
+// when entering edit mode 
 document.addEventListener('aue:ui-edit', () => {
+  // stop autoscrolling for all carousels
   document.querySelectorAll('.block.carousel').forEach( (carousel) => {
-      stopInterval(carousel);
+    clearTimeout(carousel.dataset.timeoutId)
   });
-});
+});I
 
-// when entering preview mode start scrolling
+// when entering preview mode 
 document.addEventListener('aue:ui-preview', () => {
+  // restart autoscrolling for all carousels
   document.querySelectorAll('.block.carousel').forEach( (carousel) => {
-      startInterval(carousel);
+    carousel.dataset.timeoutId = setTimeout(timeout,carousel.dataset.timeoutMs,carousel)
   });
 });
 

--- a/scripts/editor-support.js
+++ b/scripts/editor-support.js
@@ -202,7 +202,7 @@ document.addEventListener('aue:ui-edit', () => {
   document.querySelectorAll('.block.carousel').forEach( (carousel) => {
     clearTimeout(carousel.dataset.timeoutId)
   });
-});I
+});
 
 // when entering preview mode 
 document.addEventListener('aue:ui-preview', () => {

--- a/scripts/editor-support.js
+++ b/scripts/editor-support.js
@@ -48,6 +48,13 @@ function setState(block, state) {
   }
 }
 
+function stopAutoScrolling() {
+  // stop autoscrolling for all carousels
+  document.querySelectorAll('.block.carousel').forEach( (carousel) => {
+    stopAutoScroll(carousel);
+  });
+}
+
 // set the filter for an UE editable
 function setUEFilter(element, filter) {
   element.dataset.aueFilter = filter;
@@ -186,6 +193,7 @@ function attachEventListners(main) {
     const applied = await applyChanges(event);
     if (applied) {
       updateUEInstrumentation();
+      stopAutoScrolling();
     } else {
       window.location.reload();
     }
@@ -200,7 +208,7 @@ attachEventListners(document.querySelector('main'));
 document.addEventListener('aue:ui-edit', () => {
   // stop autoscrolling for all carousels
   document.querySelectorAll('.block.carousel').forEach( (carousel) => {
-    stopAutoScroll(carousel);
+    setTimeout(stopAutoScroll,500,carousel);
   });
 });
 

--- a/scripts/editor-support.js
+++ b/scripts/editor-support.js
@@ -1,4 +1,4 @@
-import { showSlide, timeout } from '../blocks/carousel/carousel.js';
+import { showSlide, startAutoScroll, stopAutoScroll } from '../blocks/carousel/carousel.js';
 import {
   decorateBlock,
   decorateBlocks,
@@ -200,7 +200,7 @@ attachEventListners(document.querySelector('main'));
 document.addEventListener('aue:ui-edit', () => {
   // stop autoscrolling for all carousels
   document.querySelectorAll('.block.carousel').forEach( (carousel) => {
-    clearTimeout(carousel.dataset.timeoutId)
+    stopAutoScroll(carousel);
   });
 });
 
@@ -208,7 +208,7 @@ document.addEventListener('aue:ui-edit', () => {
 document.addEventListener('aue:ui-preview', () => {
   // restart autoscrolling for all carousels
   document.querySelectorAll('.block.carousel').forEach( (carousel) => {
-    carousel.dataset.timeoutId = setTimeout(timeout,carousel.dataset.timeoutMs,carousel)
+    startAutoScroll(carousel);
   });
 });
 

--- a/scripts/editor-support.js
+++ b/scripts/editor-support.js
@@ -43,6 +43,7 @@ function setState(block, state) {
   }
   if (block.matches('.carousel')) {
     block.style.display = null;
+    stopInterval(block);
     createMutation(block);
     showSlide(block, state);
   }


### PR DESCRIPTION
- The carousel block in citisignal has animated indicators for autoscroll
- the implementation is done with an intervall that triggers every 50 ms
- this causes an overload of  events causing UE to stop working properly (content tree no longer updates)

changes:
- made timeout configurable on the carousel itself, default 5000 seconds
- switched animation form js to CSS
- fixed some more bugs/issues, problems with UE